### PR TITLE
Added origin parameter to `init-sdk` api call

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -3,6 +3,7 @@
 ## X.X.X (TBA)
 
 - Added `onboardingApproval` to the `WDOStatusCheckReason` when the process is waiting for institution approval.
+- SDK now supports server that is configured to support multiple BlinkID applications (bundle IDs/Package Names). The `origin` parameter is now sent to the server to identify the application.
 
 ## 1.2.0 (Jan, 2026)
 

--- a/packages/lib-cordova/src/WDOCordovaPlatform.ts
+++ b/packages/lib-cordova/src/WDOCordovaPlatform.ts
@@ -11,19 +11,19 @@ import "cordova-powerauth-mobile-sdk"
 import { WDOApiEndpoint, WDOCache, WDONetworking, WDONetworkingIntegration, WDOPlatformUtils } from '../../lib-shared/src/WDOPlatform'
 import { WPNEndpoint, WPNNetworking } from "cordova-powerauth-networking"
 
-declare var cordova: any
-
 /* @internal */
 export class WDOCordovaPlatformUtils implements WDOPlatformUtils {
     crossPlatformName(): "cordova" | "react-native" {
         return "cordova"
     }
 
-    nativePlatformName(): "ios" | "android" {
-        if (cordova.platformId === "ios") {
-            return "ios"
-        } else {
+    async nativePlatformName(): Promise<"ios" | "android"> {
+        // lets keep it simple for now
+        const systemName = (await PowerAuthUtils.getEnvironmentInfo()).systemName.toLowerCase()
+        if (systemName === "android") {
             return "android"
+        } else {
+            return "ios"
         }
     }
 

--- a/packages/lib-cordova/src/WDOCordovaPlatform.ts
+++ b/packages/lib-cordova/src/WDOCordovaPlatform.ts
@@ -8,9 +8,31 @@
  */
 
 import "cordova-powerauth-mobile-sdk"
-import { WDOApiEndpoint, WDOCache, WDONetworking, WDONetworkingIntegration } from '../../lib-shared/src/WDOPlatform'
+import { WDOApiEndpoint, WDOCache, WDONetworking, WDONetworkingIntegration, WDOPlatformUtils } from '../../lib-shared/src/WDOPlatform'
 import { WPNEndpoint, WPNNetworking } from "cordova-powerauth-networking"
 
+declare var cordova: any
+
+/* @internal */
+export class WDOCordovaPlatformUtils implements WDOPlatformUtils {
+    crossPlatformName(): "cordova" | "react-native" {
+        return "cordova"
+    }
+
+    nativePlatformName(): "ios" | "android" {
+        if (cordova.platformId === "ios") {
+            return "ios"
+        } else {
+            return "android"
+        }
+    }
+
+    async bundleId(): Promise<string | undefined> {
+        return (await PowerAuthUtils.getEnvironmentInfo()).applicationIdentifier
+    }
+}
+
+/* @internal */
 export class WDOCordovaCache implements WDOCache {
 
     set(key: string, value: string | undefined): Promise<void> {
@@ -30,6 +52,7 @@ export class WDOCordovaCache implements WDOCache {
     }
 }
 
+/* @internal */
 export class WDONetworkingCordovaIntegration implements WDONetworkingIntegration {
 
     signedEndpoint<TRequest, TResponse>(path: string, uriId: string, responseConfig?: any, e2eeConfig?: any): WDOApiEndpoint<TRequest, TResponse> {
@@ -49,6 +72,7 @@ export class WDONetworkingCordovaIntegration implements WDONetworkingIntegration
     }
 }
 
+/* @internal */
 export class WDOPowerAuthCordovaIntegration {
 
     activationWithActivationCode(activationCode: string, activationName: string, otp: string | undefined): PowerAuthActivation {

--- a/packages/lib-cordova/src/WDOCordovaPlatform.ts
+++ b/packages/lib-cordova/src/WDOCordovaPlatform.ts
@@ -13,13 +13,23 @@ import { WPNEndpoint, WPNNetworking } from "cordova-powerauth-networking"
 
 /* @internal */
 export class WDOCordovaPlatformUtils implements WDOPlatformUtils {
+
+    private cachedEnvInfo: PowerAuthEnvironmentInfo | null = null
+
+    private async getEnvironmentInfo(): Promise<PowerAuthEnvironmentInfo> {
+        if (this.cachedEnvInfo === null) {
+            this.cachedEnvInfo = await PowerAuthUtils.getEnvironmentInfo()
+        }
+        return this.cachedEnvInfo
+    }
+
     crossPlatformName(): "cordova" | "react-native" {
         return "cordova"
     }
 
     async nativePlatformName(): Promise<"ios" | "android"> {
         // lets keep it simple for now
-        const systemName = (await PowerAuthUtils.getEnvironmentInfo()).systemName.toLowerCase()
+        const systemName = (await this.getEnvironmentInfo()).systemName.toLowerCase()
         if (systemName === "android") {
             return "android"
         } else {
@@ -28,7 +38,7 @@ export class WDOCordovaPlatformUtils implements WDOPlatformUtils {
     }
 
     async bundleId(): Promise<string | undefined> {
-        return (await PowerAuthUtils.getEnvironmentInfo()).applicationIdentifier
+        return (await this.getEnvironmentInfo()).applicationIdentifier
     }
 }
 

--- a/packages/lib-cordova/src/index.ts
+++ b/packages/lib-cordova/src/index.ts
@@ -16,11 +16,12 @@ export * from '../../lib-shared/src/api/WDONetworkingObjects'
 export * from '../../lib-shared/src/WDOError'
 
 // setup platform specific implementations
-import { WDOCordovaCache, WDONetworkingCordovaIntegration, WDOPowerAuthCordovaIntegration } from './WDOCordovaPlatform'
+import { WDOCordovaCache, WDOCordovaPlatformUtils, WDONetworkingCordovaIntegration, WDOPowerAuthCordovaIntegration } from './WDOCordovaPlatform'
 import { WDOPlatform } from '../../lib-shared/src/WDOPlatform'
 WDOPlatform.cache = new WDOCordovaCache()
 WDOPlatform.networking = new WDONetworkingCordovaIntegration()
 WDOPlatform.powerAuth = new WDOPowerAuthCordovaIntegration()
+WDOPlatform.utils = new WDOCordovaPlatformUtils()
 
 // services that depend on platform implementations
 import { WDOBaseActivationService } from '../../lib-shared/src/WDOActivationService'

--- a/packages/lib-shared/src/WDOPlatform.ts
+++ b/packages/lib-shared/src/WDOPlatform.ts
@@ -25,7 +25,7 @@ export interface WDOCache {
 /* @internal */
 export interface WDOPlatformUtils {
     crossPlatformName(): "cordova" | "react-native"
-    nativePlatformName(): "ios" | "android"
+    nativePlatformName(): Promise<"ios" | "android">
     bundleId(): Promise<string | undefined>
 }
 

--- a/packages/lib-shared/src/WDOPlatform.ts
+++ b/packages/lib-shared/src/WDOPlatform.ts
@@ -7,16 +7,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* @internal */
 export class WDOPlatform {
     static cache: WDOCache
     static networking: WDONetworkingIntegration
     static powerAuth: WDOPowerAuthIntegration
+    static utils: WDOPlatformUtils
 }
 
+/* @internal */
 export interface WDOCache {
     set(key: string, value: string | undefined): Promise<void>
     get(key: string): Promise<string | undefined>
     has(key: string): Promise<boolean>
+}
+
+/* @internal */
+export interface WDOPlatformUtils {
+    crossPlatformName(): "cordova" | "react-native"
+    nativePlatformName(): "ios" | "android"
+    bundleId(): Promise<string | undefined>
 }
 
 /* @internal */

--- a/packages/lib-shared/src/api/WDOApi.ts
+++ b/packages/lib-shared/src/api/WDOApi.ts
@@ -82,8 +82,8 @@ export class WDOApi<TPowerAuth extends WDOPowerAuth> {
         return this.callApi(requestObject, WDOVerificationEndpoints.consentApprove)
     }
 
-    verificationInitScanSDK(processId: string, challenge: string): Promise<any> {
-        const requestObject = { processId: processId, attributes: { 'sdk-init-token': challenge }} 
+    async verificationInitScanSDK(processId: string, challenge: string): Promise<any> {
+        const requestObject = { processId: processId, attributes: { 'sdk-init-token': challenge, platform: WDOPlatform.utils.nativePlatformName(), origin: await WDOPlatform.utils.bundleId() } } 
         return this.callApi(requestObject, WDOVerificationEndpoints.documentScanSdkInit)
     }
 

--- a/packages/lib-shared/src/api/WDOApi.ts
+++ b/packages/lib-shared/src/api/WDOApi.ts
@@ -83,7 +83,7 @@ export class WDOApi<TPowerAuth extends WDOPowerAuth> {
     }
 
     async verificationInitScanSDK(processId: string, challenge: string): Promise<any> {
-        const requestObject = { processId: processId, attributes: { 'sdk-init-token': challenge, platform: WDOPlatform.utils.nativePlatformName(), origin: await WDOPlatform.utils.bundleId() } } 
+        const requestObject = { processId: processId, attributes: { 'sdk-init-token': challenge, platform: await WDOPlatform.utils.nativePlatformName(), origin: await WDOPlatform.utils.bundleId() } } 
         return this.callApi(requestObject, WDOVerificationEndpoints.documentScanSdkInit)
     }
 


### PR DESCRIPTION
Fixed #25

- added `origin` parameter to the call
- added `platform` parameter (which was already there but not implemented) to the call