### PR TITLE
Fixed #46 - auto assign document original ID

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## X.X.X (TBA)
+## X.X.X (TBD)
+
+- When re-uploading a rejected document without providing `originalDocumentId`, the SDK now resolves it automatically.
+- `WDODocumentSide` enum values changed from lowercase (`"front"`, `"back"`) to uppercase (`"FRONT"`, `"BACK"`) to match server API values.
+
+## 2.0.1 (Mar, 2026)
 
 - Fixed: Document scan flow no longer proceeds to processing when additional documents are still selected locally.
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -3,6 +3,7 @@
 ## X.X.X (TBD)
 
 - When re-uploading a rejected document without providing `originalDocumentId`, the SDK now resolves it automatically.
+  - Matching is based on the server data provided during the `status()` call, which includes the list of documents and their sides that the user already uploaded.
 - `WDODocumentSide` enum values changed from lowercase (`"front"`, `"back"`) to uppercase (`"FRONT"`, `"BACK"`) to match server API values.
 
 ## 2.0.1 (Mar, 2026)

--- a/packages/lib-shared/src/WDODocumentFile.ts
+++ b/packages/lib-shared/src/WDODocumentFile.ts
@@ -7,7 +7,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { WDODocumentSubmitFileSide } from "./api/WDONetworkingObjects"
 import { WDOScannedDocument } from "./WDOVerificationScanProcess"
 
 /** String that contains a Base64 encoded JPEG image */
@@ -97,17 +96,7 @@ export enum WDODocumentSide {
      * When a document has more than one side but only one side is used (for example, passport),
      * then such a side is considered to be front.
      */
-    front = "front",
+    front = "FRONT",
     /** Backside of a document */
-    back = "back"
-}
-
-/* @internal */
-export function WDOCreateDocumentSubmitFileSide(side: WDODocumentSide): WDODocumentSubmitFileSide {
-    switch (side) {
-        case WDODocumentSide.front:
-            return WDODocumentSubmitFileSide.front
-        case WDODocumentSide.back:
-            return WDODocumentSubmitFileSide.back
-    }
+    back = "BACK"
 }

--- a/packages/lib-shared/src/WDOVerificationScanProcess.ts
+++ b/packages/lib-shared/src/WDOVerificationScanProcess.ts
@@ -7,8 +7,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { WDODocument } from "./api/WDONetworkingObjects"
-import { WDODocumentSide, WDODocumentType } from "./WDODocumentFile"
+import type { WDODocument } from "./api/WDONetworkingObjects"
+import type { WDODocumentSide, WDODocumentType } from "./WDODocumentFile"
 import { WDOLogger } from "./WDOLogger"
 
 /** Describes the state of documents that need to be uploaded to the server. */

--- a/packages/lib-shared/src/WDOVerificationScanProcess.ts
+++ b/packages/lib-shared/src/WDOVerificationScanProcess.ts
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { WDODocument, WDODocumentSubmitFileSide } from "./api/WDONetworkingObjects"
+import { WDODocument } from "./api/WDONetworkingObjects"
 import { WDODocumentSide, WDODocumentType } from "./WDODocumentFile"
 import { WDOLogger } from "./WDOLogger"
 
@@ -29,17 +29,10 @@ export class WDOVerificationScanProcess {
 
     /* @internal */
     feedServerData(documents: WDODocument[]) {
-        const groups = documents.reduce<Map<string, WDODocument[]>>((map, doc) => {
-            const key = doc.type
-            const group = map.get(key) ?? []
-            group.push(doc)
-            map.set(key, group)
-            return map
-        }, new Map())
-
-        groups.forEach((docs, type) => {
-            this.documents.find(d => d.type === type)?.processServerData(docs)
-        })
+        for (const documentToScan of this.documents) {
+            let serverDocuments = documents.filter(d => d.type === documentToScan.type)
+            documentToScan.processServerData(serverDocuments)
+        }
     }
 
     /* @internal */
@@ -97,7 +90,7 @@ export class WDOScannedDocument {
 
     /* @internal */
     processServerData(documents: WDODocument[]) {
-        this._sides = documents.map(doc => new Side(doc.side == WDODocumentSubmitFileSide.front ? WDODocumentSide.front : WDODocumentSide.back, doc.id, (doc.errors?.length ?? 0) > 0 ? UploadState.rejected : UploadState.accepted))
+        this._sides = documents.map(doc => new Side(doc.side, doc.id, (doc.errors?.length ?? 0) > 0 ? UploadState.rejected : UploadState.accepted))
     }
 }
 

--- a/packages/lib-shared/src/WDOVerificationScanProcess.ts
+++ b/packages/lib-shared/src/WDOVerificationScanProcess.ts
@@ -3,7 +3,7 @@
  *
  * This source code is licensed under the Apache License, Version 2.0 license
  * found in the LICENSE file in the root directory of this source tree.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -23,8 +23,12 @@ export class WDOVerificationScanProcess {
     }
 
     /* @internal */
-    constructor(types: WDODocumentType[]) {
-        this.documents = types.map(t => new WDOScannedDocument(t))
+    constructor(input: WDODocumentType[] | WDOScannedDocument[]) {
+        if (input.length > 0 && input[0] instanceof WDOScannedDocument) {
+            this.documents = input as WDOScannedDocument[]
+        } else {
+            this.documents = (input as WDODocumentType[]).map(t => new WDOScannedDocument(t))
+        }
     }
 
     /* @internal */
@@ -37,22 +41,49 @@ export class WDOVerificationScanProcess {
 
     /* @internal */
     static fromCachedData(data: string): WDOVerificationScanProcess | undefined {
-        const split = data.split(":")
-        if (split.length != 2) {
-            WDOLogger.error("WDOVerificationScanProcess.fromCachedData: invalid cached data format")
+        // v1 format: "v1:TYPE1,TYPE2,..."
+        if (data.startsWith("v1:")) {
+            const split = data.split(":")
+            if (split.length != 2) {
+                WDOLogger.error("WDOVerificationScanProcess.fromCachedData: invalid v1 cached data format")
+                return undefined
+            }
+            const types = split[1].split(",")
+            return new WDOVerificationScanProcess(types as WDODocumentType[])
+        }
+
+        // v2 format: JSON
+        try {
+            const parsed = JSON.parse(data) as CacheV2
+            if (parsed.v !== 2) {
+                WDOLogger.error(`WDOVerificationScanProcess.fromCachedData: unsupported cached data version: ${parsed.v}`)
+                return undefined
+            }
+            const documents = parsed.documents.map(d => {
+                const sides = d.sides.map(s => new Side(s.type as WDODocumentSide, s.serverId, s.uploadState))
+                return new WDOScannedDocument(d.type as WDODocumentType, sides)
+            })
+            return new WDOVerificationScanProcess(documents)
+        } catch (e) {
+            WDOLogger.error(`WDOVerificationScanProcess.fromCachedData: failed to parse cached data: ${e}`)
             return undefined
         }
-        if (split[0] !== "v1") {
-            WDOLogger.error("WDOVerificationScanProcess.fromCachedData: unsupported cached data version")
-            return undefined
-        }
-        const types = split[1].split(",")
-        return new WDOVerificationScanProcess(types)
     }
 
     /* @internal */
     dataForCache(): string {
-        return `v1:${this.documents.map(d => { return d.type }).join(",")}`
+        const data: CacheV2 = {
+            v: 2,
+            documents: this.documents.map(d => ({
+                type: d.type,
+                sides: d.sides.map(s => ({
+                    type: s.type,
+                    serverId: s.serverId,
+                    uploadState: s.uploadState
+                }))
+            }))
+        }
+        return JSON.stringify(data)
     }
 }
 
@@ -79,13 +110,14 @@ export class WDOScannedDocument {
 
     /** Sides of the document that were uploaded on the server. */
     get sides(): Side[] { return this._sides }
-    
-    /* @internal */
-    private _sides = new Array<Side>()
 
     /* @internal */
-    constructor(type: WDODocumentType) {
+    private _sides: Side[]
+
+    /* @internal */
+    constructor(type: WDODocumentType, initialSides?: Side[]) {
         this.type = type
+        this._sides = initialSides ?? []
     }
 
     /* @internal */
@@ -95,26 +127,26 @@ export class WDOScannedDocument {
 }
 
 /** State of the document on the server. */
-export enum UploadState {    
+export enum UploadState {
     /** The document was not uploaded yet. */
     notUploaded,
-    
+
     /** The server accepted the document. */
     accepted,
-    
+
     /** The document was rejected and needs to be re-uploaded. */
     rejected
 }
 
 /** Side of the uploaded document. */
 export class Side {
-    
+
     /** Type of the side. */
     public type: WDODocumentSide
-    
+
     /** ID on the server. Use this ID in case of an reupload */
     public serverId: string
-    
+
     /** Upload state of the document */
     public uploadState: UploadState
 
@@ -124,4 +156,25 @@ export class Side {
         this.serverId = serverId
         this.uploadState = uploadState
     }
+}
+
+// Cache format types
+
+/* @internal */
+interface CacheV2Side {
+    type: string
+    serverId: string
+    uploadState: number
+}
+
+/* @internal */
+interface CacheV2Document {
+    type: string
+    sides: CacheV2Side[]
+}
+
+/* @internal */
+interface CacheV2 {
+    v: 2
+    documents: CacheV2Document[]
 }

--- a/packages/lib-shared/src/WDOVerificationService.ts
+++ b/packages/lib-shared/src/WDOVerificationService.ts
@@ -176,6 +176,7 @@ export abstract class WDOBaseVerificationService<
                     if (cachedProcess) {
 
                         cachedProcess.feedServerData(documents)
+                        await this.setCachedProcess(cachedProcess)
 
                         if (documents.some(d => documentAction(d) === "error") || documents.some(d => d.errors != undefined && d.errors.length > 0)) {
                             WDOLogger.debug(`At least one document in error state: ${documents.some(d => documentAction(d) === "error")}, ${documents.some(d => d.errors != undefined && d.errors.length > 0)}`)
@@ -263,6 +264,7 @@ export abstract class WDOBaseVerificationService<
         }
 
         await this.handleError(this.api.verificationStart(pid))
+        await this.setCachedProcess(undefined) // clear cache when starting the verification
         return this.processState({ type: WDOVerificationStateType.documentsToScanSelect })
     }
 
@@ -308,21 +310,16 @@ export abstract class WDOBaseVerificationService<
         const pid = this.verifyHasActiveProcess()
 
         // --
-        // Following block is a fallback mechanism to find originalDocumentId for documents that are being re-uploaded without originalDocumentId, based on the cached process and the server status of documents. 
-        // This is to handle the case when integrator is uploading the same document again without providing the originalDocumentId, but we can find the original document ID from the cached process based on the type and side. 
+        // Following block fills in originalDocumentId for documents being re-uploaded without it.
+        // The cached process is kept up-to-date with server-side IDs after each status() call,
+        // so no extra server call is needed here.
         // The recommended way is to always provide the originalDocumentId when re-uploading the same document.
         // Note that this will be improved on the backend in the future via https://github.com/wultra/enrollment-server/issues/1650
         {
-            // First we check if there are any documents without originalDocumentId, if not, we can skip this block
             const filesWithoutOriginalId = files.filter(f => f.originalDocumentId == undefined)
-            const cachedProcess = await this.getCachedProcess()
-            if (cachedProcess && filesWithoutOriginalId.length > 0) {
-                // Now fetch documents already uploaded to the server
-                const serverDocuments = (await this.api.verificationDocumentsStatus(pid)).documents
-                // Feed the data to the process
-                cachedProcess.feedServerData(serverDocuments)
+            const cachedProcess = filesWithoutOriginalId.length > 0 ? await this.getCachedProcess() : undefined
+            if (cachedProcess) {
                 WDOLogger.debug(`Found cached process with documents: ${cachedProcess.documents.map(d => d.type + " " + `${d.sides.length} sides ` + d.sides.map(s => s.type).join("/")).join(", ")}`)
-                // Try to find originalDocumentId for documents that are being re-uploaded without originalDocumentId based on the cached process
                 for (const file of filesWithoutOriginalId) {
                     WDOLogger.debug(`Document ${file.type} ${file.side} does not have originalDocumentId, trying to find it from cached process...`)
                     const originalDocumentId = cachedProcess.documents.find(d => d.type == file.type)?.sides.find(s => s.type == file.side)?.serverId
@@ -335,7 +332,7 @@ export abstract class WDOBaseVerificationService<
                 }
             }
         }
-        // -- End of the fallback mechanism for finding originalDocumentId from cached process. Now, all documents should have originalDocumentId if they are re-uploads, otherwise they will be treated as new uploads.
+        // -- All documents should now have originalDocumentId if they are re-uploads, otherwise they will be treated as new uploads.
 
         const resubmit = files.some(f => f.originalDocumentId != undefined)
 

--- a/packages/lib-shared/src/WDOVerificationService.ts
+++ b/packages/lib-shared/src/WDOVerificationService.ts
@@ -84,16 +84,16 @@ export abstract class WDOBaseVerificationService<
     protected lastStatus: WDOIdentityStatusResponse | undefined = undefined
 
     /* @internal */
-    private cacheKey(): string { return `wdocp_${this.powerauth.instanceId}` }
+    private cacheKey(pid: string): string { return `wdocp_${pid}` }
 
     /* @internal */
-    private async setCachedProcess(process: WDOVerificationScanProcess | undefined): Promise<void> {
-        await WDOPlatform.cache.set(this.cacheKey(), process?.dataForCache())
+    private async setCachedProcess(pid: string, process: WDOVerificationScanProcess | undefined): Promise<void> {
+        await WDOPlatform.cache.set(this.cacheKey(pid), process?.dataForCache())
     }
 
     /* @internal */
-    private async getCachedProcess(): Promise<WDOVerificationScanProcess | undefined> {
-        const data = await WDOPlatform.cache.get(this.cacheKey())
+    private async getCachedProcess(pid: string): Promise<WDOVerificationScanProcess | undefined> {
+        const data = await WDOPlatform.cache.get(this.cacheKey(pid))
         if (!data) {
             return undefined
         }
@@ -148,7 +148,7 @@ export abstract class WDOBaseVerificationService<
                 case WDOIdentityVerificationStatus.notInitialized:
                 case WDOIdentityVerificationStatus.accepted:
                     WDOLogger.debug(`Status ${response.identityVerificationStatus} - clearing cache`)
-                    await this.setCachedProcess(undefined)
+                    await this.setCachedProcess(response.processId, undefined)
                     break
                 default:
                     // no-op
@@ -171,12 +171,12 @@ export abstract class WDOBaseVerificationService<
                     const documents = docsResponse.documents
 
                     // local state of documents that the user has selected to provide
-                    const cachedProcess = await this.getCachedProcess()
+                    const cachedProcess = await this.getCachedProcess(response.processId)
 
                     if (cachedProcess) {
 
                         cachedProcess.feedServerData(documents)
-                        await this.setCachedProcess(cachedProcess)
+                        await this.setCachedProcess(response.processId, cachedProcess)
 
                         if (documents.some(d => documentAction(d) === "error") || documents.some(d => d.errors != undefined && d.errors.length > 0)) {
                             WDOLogger.debug(`At least one document in error state: ${documents.some(d => documentAction(d) === "error")}, ${documents.some(d => d.errors != undefined && d.errors.length > 0)}`)
@@ -264,7 +264,7 @@ export abstract class WDOBaseVerificationService<
         }
 
         await this.handleError(this.api.verificationStart(pid))
-        await this.setCachedProcess(undefined) // clear cache when starting the verification
+        await this.setCachedProcess(pid, undefined) // clear cache when starting the verification
         return this.processState({ type: WDOVerificationStateType.documentsToScanSelect })
     }
 
@@ -293,7 +293,7 @@ export abstract class WDOBaseVerificationService<
     async documentsSetSelectedTypes(types: WDODocumentType[]): Promise<WDOVerificationState> {
         WDOLogger.debug(`Submitting selected document types: ${types}`)
         const process = new WDOVerificationScanProcess(types)
-        await this.setCachedProcess(process)
+        await this.setCachedProcess(this.verifyHasActiveProcess(), process)
         return this.processState({ type: WDOVerificationStateType.scanDocument, process: process })
     }
 
@@ -301,13 +301,19 @@ export abstract class WDOBaseVerificationService<
      * Upload document files to the server. The order of the documents is up to you. 
      * Make sure that uploaded document is reasonable size so you're not uploading large files.
      * 
-     * If you're uploading the same document file again, you need to include the `originalDocumentId` otherwise it will be rejected by the server.
+     * If you're uploading the same document file again, you need to include the `originalDocumentId`. If you don't include it,
+     * this method will try to resolve the `originalDocumentId` from the cached process, so if you have previously uploaded the same document type and side, 
+     * you can skip providing `originalDocumentId` here, and it will be filled in automatically. The recommended way is to always provide `originalDocumentId` when re-uploading the same document.
      * 
      * @param files Document files to upload.
      */
     async documentsSubmit(files: WDODocumentFile[]): Promise<WDOVerificationState> {
         
         const pid = this.verifyHasActiveProcess()
+
+        const processedFiles = files.map(f => {
+            return new WDODocumentFile(f.data, f.type, f.side, f.originalDocumentId, f.dataSignature) // clone the file to avoid mutating the original one with resolved originalDocumentId
+        })
 
         // --
         // Following block fills in originalDocumentId for documents being re-uploaded without it.
@@ -316,8 +322,8 @@ export abstract class WDOBaseVerificationService<
         // The recommended way is to always provide the originalDocumentId when re-uploading the same document.
         // Note that this will be improved on the backend in the future via https://github.com/wultra/enrollment-server/issues/1650
         {
-            const filesWithoutOriginalId = files.filter(f => f.originalDocumentId == undefined)
-            const cachedProcess = filesWithoutOriginalId.length > 0 ? await this.getCachedProcess() : undefined
+            const filesWithoutOriginalId = processedFiles.filter(f => f.originalDocumentId == undefined)
+            const cachedProcess = filesWithoutOriginalId.length > 0 ? await this.getCachedProcess(pid) : undefined
             if (cachedProcess) {
                 WDOLogger.debug(`Found cached process with documents: ${cachedProcess.documents.map(d => d.type + " " + `${d.sides.length} sides ` + d.sides.map(s => s.type).join("/")).join(", ")}`)
                 for (const file of filesWithoutOriginalId) {
@@ -334,9 +340,9 @@ export abstract class WDOBaseVerificationService<
         }
         // -- All documents should now have originalDocumentId if they are re-uploads, otherwise they will be treated as new uploads.
 
-        const resubmit = files.some(f => f.originalDocumentId != undefined)
+        const resubmit = processedFiles.some(f => f.originalDocumentId != undefined)
 
-        const submitFiles: WDODocumentSubmitFile[] = files.map(f => {
+        const submitFiles: WDODocumentSubmitFile[] = processedFiles.map(f => {
 
             return {
                 filename: `${f.type.toLowerCase()}_${f.side.toLowerCase()}.jpg`,
@@ -375,7 +381,7 @@ export abstract class WDOBaseVerificationService<
     async restartVerification(): Promise<WDOVerificationState> {
         const pid = this.verifyHasActiveProcess()
         await this.handleError(this.api.verificationCleanup(pid))
-        await this.setCachedProcess(undefined)
+        await this.setCachedProcess(pid, undefined)
         WDOLogger.info("Verification process restarted.")
         // return new status
         return await this.status()
@@ -388,7 +394,7 @@ export abstract class WDOBaseVerificationService<
     async cancelWholeProcess(): Promise<void> {
         const pid = this.verifyHasActiveProcess()
         await this.handleError(this.api.verificationCleanup(pid))
-        await this.setCachedProcess(undefined)
+        await this.setCachedProcess(pid, undefined)
         WDOLogger.info("Verification process canceled.")
     }
 

--- a/packages/lib-shared/src/WDOVerificationService.ts
+++ b/packages/lib-shared/src/WDOVerificationService.ts
@@ -318,7 +318,7 @@ export abstract class WDOBaseVerificationService<
             const cachedProcess = await this.getCachedProcess()
             if (cachedProcess && filesWithoutOriginalId.length > 0) {
                 // Now fetch documents already uploaded to the server
-                const serverDocuments = await (await this.api.verificationDocumentsStatus(pid)).documents
+                const serverDocuments = (await this.api.verificationDocumentsStatus(pid)).documents
                 // Feed the data to the process
                 cachedProcess.feedServerData(serverDocuments)
                 WDOLogger.debug(`Found cached process with documents: ${cachedProcess.documents.map(d => d.type + " " + `${d.sides.length} sides ` + d.sides.map(s => s.type).join("/")).join(", ")}`)

--- a/packages/lib-shared/src/WDOVerificationService.ts
+++ b/packages/lib-shared/src/WDOVerificationService.ts
@@ -311,34 +311,8 @@ export abstract class WDOBaseVerificationService<
         
         const pid = this.verifyHasActiveProcess()
 
-        const processedFiles = files.map(f => {
-            return new WDODocumentFile(f.data, f.type, f.side, f.originalDocumentId, f.dataSignature) // clone the file to avoid mutating the original one with resolved originalDocumentId
-        })
-
-        // --
-        // Following block fills in originalDocumentId for documents being re-uploaded without it.
-        // The cached process is kept up-to-date with server-side IDs after each status() call,
-        // so no extra server call is needed here.
-        // The recommended way is to always provide the originalDocumentId when re-uploading the same document.
-        // Note that this will be improved on the backend in the future via https://github.com/wultra/enrollment-server/issues/1650
-        {
-            const filesWithoutOriginalId = processedFiles.filter(f => f.originalDocumentId == undefined)
-            const cachedProcess = filesWithoutOriginalId.length > 0 ? await this.getCachedProcess(pid) : undefined
-            if (cachedProcess) {
-                WDOLogger.debug(`Found cached process with documents: ${cachedProcess.documents.map(d => d.type + " " + `${d.sides.length} sides ` + d.sides.map(s => s.type).join("/")).join(", ")}`)
-                for (const file of filesWithoutOriginalId) {
-                    WDOLogger.debug(`Document ${file.type} ${file.side} does not have originalDocumentId, trying to find it from cached process...`)
-                    const originalDocumentId = cachedProcess.documents.find(d => d.type == file.type)?.sides.find(s => s.type == file.side)?.serverId
-                    if (originalDocumentId) {
-                        WDOLogger.debug(`Found originalDocumentId ${originalDocumentId} for document ${file.type} ${file.side} from cached process`)
-                        file.originalDocumentId = originalDocumentId
-                    } else {
-                        WDOLogger.debug(`Original document ID not found for document ${file.type} ${file.side} in cached process`)
-                    }
-                }
-            }
-        }
-        // -- All documents should now have originalDocumentId if they are re-uploads, otherwise they will be treated as new uploads.
+        // process the documents to fill in originalDocumentId when missing
+        const processedFiles = await this.processDocumentsToUpload(pid, files)
 
         const resubmit = processedFiles.some(f => f.originalDocumentId != undefined)
 
@@ -508,6 +482,37 @@ export abstract class WDOBaseVerificationService<
     }
 
     // PRIVATE METHODS
+
+    /* @internal */
+    private async processDocumentsToUpload(pid: string, documents: WDODocumentFile[]): Promise<WDODocumentFile[]> {
+        // clone the documents to avoid mutating the original ones with resolved originalDocumentId
+        const processedFiles = documents.map(f => {
+            return new WDODocumentFile(f.data, f.type, f.side, f.originalDocumentId, f.dataSignature)
+        })
+
+        // Following block fills in originalDocumentId for documents being re-uploaded without it.
+        // The cached process is kept up-to-date with server-side IDs after each status() call,
+        // so no extra server call is needed here.
+        // The recommended way is to always provide the originalDocumentId when re-uploading the same document.
+        // Note that this will be improved on the backend in the future via https://github.com/wultra/enrollment-server/issues/1650
+        const filesWithoutOriginalId = processedFiles.filter(f => f.originalDocumentId == undefined)
+        const cachedProcess = filesWithoutOriginalId.length > 0 ? await this.getCachedProcess(pid) : undefined
+        if (cachedProcess) {
+            WDOLogger.debug(`Found cached process with documents: ${cachedProcess.documents.map(d => d.type + " " + `${d.sides.length} sides ` + d.sides.map(s => s.type).join("/")).join(", ")}`)
+            for (const file of filesWithoutOriginalId) {
+                WDOLogger.debug(`Document ${file.type} ${file.side} does not have originalDocumentId, trying to find it from cached process...`)
+                const originalDocumentId = cachedProcess.documents.find(d => d.type == file.type)?.sides.find(s => s.type == file.side)?.serverId
+                if (originalDocumentId) {
+                    WDOLogger.debug(`Found originalDocumentId ${originalDocumentId} for document ${file.type} ${file.side} from cached process`)
+                    file.originalDocumentId = originalDocumentId
+                } else {
+                    WDOLogger.debug(`Original document ID not found for document ${file.type} ${file.side} in cached process`)
+                }
+            }
+        }
+
+        return processedFiles
+    }
 
     /* @internal */
     private verifyHasActiveProcess(): string {

--- a/packages/lib-shared/src/WDOVerificationService.ts
+++ b/packages/lib-shared/src/WDOVerificationService.ts
@@ -304,7 +304,38 @@ export abstract class WDOBaseVerificationService<
      * @param files Document files to upload.
      */
     async documentsSubmit(files: WDODocumentFile[]): Promise<WDOVerificationState> {
+        
         const pid = this.verifyHasActiveProcess()
+
+        // --
+        // Following block is a fallback mechanism to find originalDocumentId for documents that are being re-uploaded without originalDocumentId, based on the cached process and the server status of documents. 
+        // This is to handle the case when integrator is uploading the same document again without providing the originalDocumentId, but we can find the original document ID from the cached process based on the type and side. 
+        // The recommended way is to always provide the originalDocumentId when re-uploading the same document.
+        // Note that this will be improved on the backend in the future via https://github.com/wultra/enrollment-server/issues/1650
+        {
+            // First we check if there are any documents without originalDocumentId, if not, we can skip this block
+            const filesWithoutOriginalId = files.filter(f => f.originalDocumentId == undefined)
+            const cachedProcess = await this.getCachedProcess()
+            if (cachedProcess && filesWithoutOriginalId.length > 0) {
+                // Now fetch documents already uploaded to the server
+                const serverDocuments = await (await this.api.verificationDocumentsStatus(pid)).documents
+                // Feed the data to the process
+                cachedProcess.feedServerData(serverDocuments)
+                WDOLogger.debug(`Found cached process with documents: ${cachedProcess.documents.map(d => d.type + " " + `${d.sides.length} sides ` + d.sides.map(s => s.type).join("/")).join(", ")}`)
+                // Try to find originalDocumentId for documents that are being re-uploaded without originalDocumentId based on the cached process
+                for (const file of filesWithoutOriginalId) {
+                    WDOLogger.debug(`Document ${file.type} ${file.side} does not have originalDocumentId, trying to find it from cached process...`)
+                    const originalDocumentId = cachedProcess.documents.find(d => d.type == file.type)?.sides.find(s => s.type == file.side)?.serverId
+                    if (originalDocumentId) {
+                        WDOLogger.debug(`Found originalDocumentId ${originalDocumentId} for document ${file.type} ${file.side} from cached process`)
+                        file.originalDocumentId = originalDocumentId
+                    } else {
+                        WDOLogger.debug(`Original document ID not found for document ${file.type} ${file.side} in cached process`)
+                    }
+                }
+            }
+        }
+        // -- End of the fallback mechanism for finding originalDocumentId from cached process. Now, all documents should have originalDocumentId if they are re-uploads, otherwise they will be treated as new uploads.
 
         const resubmit = files.some(f => f.originalDocumentId != undefined)
 

--- a/packages/lib-shared/src/WDOVerificationService.ts
+++ b/packages/lib-shared/src/WDOVerificationService.ts
@@ -13,7 +13,7 @@ import { WDOLogger } from './WDOLogger'
 import { WDOError, WDOErrorReason } from './WDOError'
 import { WDOEndStateReason, WDOVerificationState, WDOVerificationStateType, WDOStatusCheckReason, WDOVerificationStateServerData } from './WDOVerificationState'
 import { WDOVerificationScanProcess } from './WDOVerificationScanProcess'
-import { WDOCreateDocumentSubmitFileSide, WDODocumentFile, WDODocumentType } from './WDODocumentFile'
+import { WDODocumentFile, WDODocumentType } from './WDODocumentFile'
 import { WDOPlatform, WDOPowerAuth, WDOPowerAuthActivationStatus, WDOPowerAuthPassword } from './WDOPlatform'
 
 /**
@@ -175,7 +175,7 @@ export abstract class WDOBaseVerificationService<
 
                     if (cachedProcess) {
 
-                        cachedProcess.feedServerData(docsResponse.documents)
+                        cachedProcess.feedServerData(documents)
 
                         if (documents.some(d => documentAction(d) === "error") || documents.some(d => d.errors != undefined && d.errors.length > 0)) {
                             WDOLogger.debug(`At least one document in error state: ${documents.some(d => documentAction(d) === "error")}, ${documents.some(d => d.errors != undefined && d.errors.length > 0)}`)
@@ -313,7 +313,7 @@ export abstract class WDOBaseVerificationService<
             return {
                 filename: `${f.type.toLowerCase()}_${f.side.toLowerCase()}.jpg`,
                 type: f.type,
-                side: WDOCreateDocumentSubmitFileSide(f.side),
+                side: f.side,
                 originalDocumentId: f.originalDocumentId,
                 data: f.data
             }

--- a/packages/lib-shared/src/api/WDONetworkingObjects.ts
+++ b/packages/lib-shared/src/api/WDONetworkingObjects.ts
@@ -6,7 +6,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { WDODocumentSide, WDODocumentType } from "../WDODocumentFile";
+import type { WDODocumentSide, WDODocumentType } from "../WDODocumentFile"
 
 export interface WDOProcessResponse {
     /** ID of the process */

--- a/packages/lib-shared/src/api/WDONetworkingObjects.ts
+++ b/packages/lib-shared/src/api/WDONetworkingObjects.ts
@@ -6,7 +6,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-import { WDODocumentType } from "../WDODocumentFile";
+import { WDODocumentSide, WDODocumentType } from "../WDODocumentFile";
 
 export interface WDOProcessResponse {
     /** ID of the process */
@@ -88,14 +88,6 @@ export enum WDOIdentityVerificationPhase {
 }
 
 /* @internal */
-export enum WDODocumentSubmitFileSide {
-    /** Front side of a document. Usually the one with the picture */
-    front = "FRONT",
-    /** Back side of a document */
-    back = "BACK"
-}
-
-/* @internal */
 export interface WDODocument {
     /** Name of the file. */
     filename: string
@@ -104,7 +96,7 @@ export interface WDODocument {
     /** Type of the file */
     type: string
     /** Side of the file */
-    side: WDODocumentSubmitFileSide
+    side: WDODocumentSide
     /** Status of the processing */
     status: WDODocumentStatus
     /** Possible errors */
@@ -136,7 +128,7 @@ export interface WDODocumentSubmitFile {
     /** Type of the document */
     type: string
     /** Side of the document (for example, front side of the ID card) */
-    side: WDODocumentSubmitFileSide
+    side: WDODocumentSide
     /** Original document ID in case of re-upload */
     originalDocumentId?: string
     /** Base64 encoded data image. */

--- a/testapp-cordova/src/index.ts
+++ b/testapp-cordova/src/index.ts
@@ -387,6 +387,7 @@ async function simulateActivation() {
         
         for (const doc of documentTypesToScan) {
 
+            // upload pictures that are expected to be rejected to test the re-upload mechanism.
             console.log(`First upload dummy document for document type ${doc.type} to test upload failure and reupload mechanism...`)
             let dummyJpeg = "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAGQDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD5/ooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooA//2Q=="
             const dummyImagesToUpload = [new WDODocumentFile(dummyJpeg, doc.type, WDODocumentSide.front)]
@@ -399,6 +400,8 @@ async function simulateActivation() {
             // we expect the dummy upload to fail and the state to remain the same, if it changed, it means that the dummy document was accepted which is not expected
             guardState(dummyUploadResult.type, WDOVerificationStateType.scanDocument)
 
+            // not we perform the real scan and upload the captured images
+            // the mechanism in the SDK should match the captured document type with the rejected dummy document and allow re-upload automatically without the need to set originalDocumentId
             console.log(`Starting BlinkID scan for document type: ${doc.type}...`)
             const result = await BlinkID.performScan(sdkSettings, sessionSettings, uxSettings)
         

--- a/testapp-cordova/src/index.ts
+++ b/testapp-cordova/src/index.ts
@@ -585,7 +585,7 @@ async function waitForStatusChange(verificationService: WDOVerificationService):
 
         if (repeatedStatus.item === WDOStatusCheckReason.onboardingApproval) {
             console.log("Process is waiting for onboarding approval from institution...")
-            // simulate approval (we assume we're on a mock service that adds "mock_" prefix to client number)
+            // simulate approval (we assume we're on a mock service that adds "mockuser_" prefix to client number)
             await approveOnboarding((verificationService as any).lastStatus.processId, `mockuser_${validUserAttributes.clientNumber}`, approveWhenApprovalNeeded)
             console.log(`Onboarding process ${approveWhenApprovalNeeded ? "approved" : "rejected"}.`)
             if (!approveWhenApprovalNeeded) {

--- a/testapp-cordova/src/index.ts
+++ b/testapp-cordova/src/index.ts
@@ -44,6 +44,10 @@ function onDeviceReady() {
     simulateActivation()
 }
 
+const approveWhenApprovalNeeded = true
+const validUserAttributes = getRandomAttributes()
+const approvalRejectReason = "Just a test reason"
+
 async function simulateActivation() {
 
     const pin = "1234"
@@ -74,13 +78,6 @@ async function simulateActivation() {
         `${serverCredentials.server}/enrollment-server-onboarding/`
     )
 
-    function getRandomAttributes(): any {
-        return {
-            clientNumber: generateRandomNumericString(),
-            birthDate: "1990/03/04"
-        }
-    }
-
     let testFinishedWithSuccess = false
 
     try {
@@ -92,6 +89,7 @@ async function simulateActivation() {
             enabled: true,
             otpForIdentification: true,
             otpForIdentityVerification: true,
+            useTemporaryActivation: false,
             documents: {
                 totalRequiredDocumentsCount: 1,
                 groups: [
@@ -100,7 +98,8 @@ async function simulateActivation() {
                         items: [
                             {
                                 type: "ID_CARD",
-                                sideCount: 2
+                                sideCount: 2,
+                                country: "CZE"
                             }
                         ]
                     }
@@ -121,6 +120,9 @@ async function simulateActivation() {
             if (!config.documents || config.documents.groups.length === 0 || config.documents.groups[0].items.length === 0) {
                 throw new Error("No documents configured for onboarding process on the server!")
             }
+            if (typeof config.useTemporaryActivation !== "boolean") {
+                throw new Error("Invalid configuration for temporary activation!")
+            }
         } else {
             console.log("No process type specified, skipping configuration fetch.")
             config = defaultConfig
@@ -133,7 +135,7 @@ async function simulateActivation() {
         // first go-through to add mandatory documents from all groups
         for (const group of config.documents.groups) {
             for (let i = 0; i < group.requiredDocumentsCount; i++) {
-                const docType = configDocToDocType(group.items[i])
+                const docType = group.items[i]
                 console.log(`Adding mandatory document from configuration group: ${docType.type}`)
                 documentTypesToScan.push(docType)
             }
@@ -152,10 +154,9 @@ async function simulateActivation() {
                 }
 
                 for (const item of group.items) {
-                    const docType = configDocToDocType(item)
-                    if (!documentTypesToScan.find(d => d.type === docType.type)) {
-                        console.log(`Adding non-mandatory document from configuration group: ${docType.type}`)
-                        documentTypesToScan.push(docType)
+                    if (!documentTypesToScan.find(d => d.type === item.type)) {
+                        console.log(`Adding non-mandatory document from configuration group: ${item.type}`)
+                        documentTypesToScan.push(item)
                         if (hasRequiredDocCount(documentTypesToScan)) {
                             break
                         }
@@ -225,7 +226,7 @@ async function simulateActivation() {
 
         // start onboarding
         console.log(`Starting second onboarding process with onboarding type: ${processType}...`)
-        await activationService.start(getRandomAttributes(), processType)
+        await activationService.start(validUserAttributes, processType)
         console.log(`Activation started:  ${await activationService.hasActiveProcess() ? "yes" : "no"}`)
 
         // get onboarding status
@@ -385,6 +386,19 @@ async function simulateActivation() {
         let blinkIDUploadResult: WDOVerificationState = docTypesResult // initial value to please the compiler
         
         for (const doc of documentTypesToScan) {
+
+            console.log(`First upload dummy document for document type ${doc.type} to test upload failure and reupload mechanism...`)
+            let dummyJpeg = "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABkAGQDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD5/ooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooA//2Q=="
+            const dummyImagesToUpload = [new WDODocumentFile(dummyJpeg, doc.type, WDODocumentSide.front)]
+            if (doc.sideCount > 1) {
+                dummyImagesToUpload.push(new WDODocumentFile(dummyJpeg, doc.type, WDODocumentSide.back))
+            }
+
+            const dummyUploadResult = await uploadDocumentsFromBlinkId(verificationService, dummyImagesToUpload)
+            console.log(`Verification status after dummy document upload: ${dummyUploadResult.type}`)
+            // we expect the dummy upload to fail and the state to remain the same, if it changed, it means that the dummy document was accepted which is not expected
+            guardState(dummyUploadResult.type, WDOVerificationStateType.scanDocument)
+
             console.log(`Starting BlinkID scan for document type: ${doc.type}...`)
             const result = await BlinkID.performScan(sdkSettings, sessionSettings, uxSettings)
         
@@ -541,8 +555,17 @@ async function simulateActivation() {
     console.log("-------------\n")
 }
 
+
+
+function getRandomAttributes(): { clientNumber: string, birthDate: string } {
+    return {
+        clientNumber: generateRandomNumericString(),
+        birthDate: "1990/03/04"
+    }
+}
+
 async function uploadDocumentsFromBlinkId(verificationService: WDOVerificationService, documents: WDODocumentFile[]): Promise<WDOVerificationState> {
-    console.log("Submitting blinkID images...")
+    console.log("Submitting images...")
     const scanResult = await verificationService.documentsSubmit(
         documents
     )
@@ -562,9 +585,23 @@ async function waitForStatusChange(verificationService: WDOVerificationService):
 
         if (repeatedStatus.item === WDOStatusCheckReason.onboardingApproval) {
             console.log("Process is waiting for onboarding approval from institution...")
-            // simulate approval
-            await approveOnboarding((verificationService as any).lastStatus.processId)
-            console.log("Onboarding process approved.")
+            // simulate approval (we assume we're on a mock service that adds "mock_" prefix to client number)
+            await approveOnboarding((verificationService as any).lastStatus.processId, `mockuser_${validUserAttributes.clientNumber}`, approveWhenApprovalNeeded)
+            console.log(`Onboarding process ${approveWhenApprovalNeeded ? "approved" : "rejected"}.`)
+            if (!approveWhenApprovalNeeded) {
+                console.log("Test is set to reject onboarding, finishing test here.")
+                let status = await verificationService.status() // return current status which should be end state with rejected reason
+                if (status.type == WDOVerificationStateType.endState) {
+
+                    if (status.rejectReason == approvalRejectReason) {
+                        console.log("Verification ended with end state as expected after onboarding rejection.")
+                        throw new Error("Onboarding was rejected as part of the test, stopping further processing.")
+                    } else {
+                        console.log(`Verification ended with end state but with unexpected reject reason: ${status.rejectReason}`)
+                        throw new Error(`Verification ended with end state but with unexpected reject reason: ${status.rejectReason}`)
+                    }
+                }
+            }
         }
 
         console.log(`Verification still processing (${repeatedStatus.item}), waiting 3 seconds before next status check...`)
@@ -592,20 +629,7 @@ function generateRandomNumericString(length: number = 10): string {
     return result
 }
 
-
-function configDocToDocType(doc: WDOConfigurationDocument): { type: WDODocumentType, sideCount: number } {
-    if (doc.type === "DRIVER_LICENSE") {
-        return { type: WDODocumentType.driversLicense, sideCount: doc.sideCount }
-    } else if (doc.type === "ID_CARD") {
-        return { type: WDODocumentType.idCard, sideCount: doc.sideCount }
-    } else if (doc.type === "PASSPORT") {
-        return { type: WDODocumentType.passport, sideCount: doc.sideCount }
-    } else {
-        throw new Error(`Unsupported document type in configuration: ${doc.type}`)
-    }
-}
-
-async function approveOnboarding(processId: string): Promise<any> {
+async function approveOnboarding(processId: string, userId: string, approve: boolean): Promise<any> {
 
     // first get verification id for the process
 
@@ -633,8 +657,9 @@ async function approveOnboarding(processId: string): Promise<any> {
     const raw = JSON.stringify({
         "processId": processId,
         "identityVerificationId": verificationId,
-        "userId": "foo",
-        "approvalResult": "OK"
+        "userId": userId,
+        "approvalResult": approve ? "OK" : "NOK",
+        "approvalResultReason": approve ? "" : approvalRejectReason
     })
 
     const requestOptions2 = {
@@ -643,8 +668,10 @@ async function approveOnboarding(processId: string): Promise<any> {
         body: raw
     }
 
+    console.log(`Submitting onboarding approval with body: ${raw}`)
     const result2 = await fetch(`${serverCredentials.server}/enrollment-server-onboarding/api/private/client/approve`, requestOptions2)
     console.log(`Onboarding approval response status for process ${processId} and verification ${verificationId}: ${result2.status}`)
+    console.log(`${await result2.text()}`)
 
     if (!result2.ok) {
         throw new Error("Failed to approve onboarding process") 


### PR DESCRIPTION
In this PR:

- auto assigning original document ID of the integrator is uploading the same document twice
- removed `WDODocumentSubmitFileSide` and now using only one enum `WDODocumentSide`.
- added a test that uploads the wrong document on purpose before uploading the BlinkID result to test if original document pairing works as expected...
- process cache is not stored based on the process id and not powerauth instance id
- process cache now stores the server data